### PR TITLE
fix: fixed email test case

### DIFF
--- a/internal/primitive/email_test.go
+++ b/internal/primitive/email_test.go
@@ -286,7 +286,8 @@ func TestEmailInvalidCreds(t *testing.T) {
 	output.HasErrors()
 	for _, e := range output.Errors {
 		assert.Equal(503, e.Error.Status)
-		assert.Equal(e.Error.Detail, "535 Username and Password not accepted")
+		assert.Equal("535", e.Error.Detail[0:3])
+		assert.Contains(e.Error.Detail, "Username and Password not accepted")
 	}
 }
 


### PR DESCRIPTION
We can't assume that the response from email server will be exactly "Username and Password not accepted" as different email hosts add custom descriptions.

For example:

`Google / GMail` returns: 
```
5.7.8 Username and Password not accepted. Learn more at https://support.google.com/mail/?p=BadCredentials e16-20020adfe390000000b0032dab20e773sm13560176wrm.69 - gsmtp
```

Where-as another provider merely returns:
```
Username and Password not accepted. - ERR_BAD_CREDS
```