### PR TITLE
Update 'flowpipe help pipeline run' help information/description. Closes #360

### DIFF
--- a/internal/cmd/pipeline.go
+++ b/internal/cmd/pipeline.go
@@ -49,9 +49,10 @@ func pipelineCmd() *cobra.Command {
 // list
 func pipelineListCmd() *cobra.Command {
 	var cmd = &cobra.Command{
-		Use:  "list",
-		Args: cobra.NoArgs,
-		Run:  listPipelineFunc,
+		Use:   "list",
+		Args:  cobra.NoArgs,
+		Run:   listPipelineFunc,
+		Short: "List pipelines from the current mod and its direct dependents.",
 	}
 	// initialize hooks
 	cmdconfig.OnCmd(cmd)
@@ -118,9 +119,10 @@ func listPipelineLocal(cmd *cobra.Command, args []string) (*types.ListPipelineRe
 // show
 func pipelineShowCmd() *cobra.Command {
 	var cmd = &cobra.Command{
-		Use:  "show <pipeline-name>",
-		Args: cobra.ExactArgs(1),
-		Run:  showPipelineFunc,
+		Use:   "show <pipeline-name>",
+		Args:  cobra.ExactArgs(1),
+		Run:   showPipelineFunc,
+		Short: "Show details of a pipeline from the current mod or its direct dependents.",
 	}
 	// initialize hooks
 	cmdconfig.OnCmd(cmd)
@@ -185,14 +187,15 @@ func getPipelineLocal(ctx context.Context, pipelineName string) (*types.FpPipeli
 // run
 func pipelineRunCmd() *cobra.Command {
 	var cmd = &cobra.Command{
-		Use:  "run <pipeline-name>",
-		Args: cobra.ExactArgs(1),
-		Run:  runPipelineFunc,
+		Use:   "run <pipeline-name>",
+		Args:  cobra.ExactArgs(1),
+		Run:   runPipelineFunc,
+		Short: "Run a pipeline from the current mod or its direct dependents or from a Flowpipe server instance.",
 	}
 
 	// Add the pipeline arg flag
 	cmdconfig.OnCmd(cmd).
-		AddStringArrayFlag(constants.ArgArg, nil, "Specify the value of a pipeline argument. Multiple --pipeline-arg may be passed.").
+		AddStringArrayFlag(constants.ArgArg, nil, "Specify the value of a pipeline argument. Multiple --arg may be passed.").
 		AddBoolFlag(constants.ArgVerbose, false, "Enable verbose output.")
 
 	return cmd


### PR DESCRIPTION
```sh
vscode ➜ /workspaces/flowpipe (main) $ go run . help pipeline run
Run a pipeline from the current mod or its direct dependents or from a Flowpipe server instance.

Usage:
  flowpipe pipeline run <pipeline-name> [flags]

Flags:
      --arg stringArray   Specify the value of a pipeline argument. Multiple --arg may be passed.
  -h, --help              help for run
      --verbose           Enable verbose output.

Global Flags:
      --config-path string    Colon separated list of paths to search for workspace files, in order of decreasing precedence
      --host string           API server host, including the port number
      --insecure              Skip TLS verification
      --mod-location string   Path to the workspace working directory (default "/workspaces/flowpipe")
      --output output         Output format; one of: pretty, plain, yaml, json (default pretty)
      --var stringArray       Specify the value of a variable
      --var-file strings      Specify an .fpvar file containing variable values
      --workspace string      The workspace to use (default "default")
vscode ➜ /workspaces/flowpipe (fix-pipeline-run-flag-description) $
vscode ➜ /workspaces/flowpipe (fix-pipeline-run-flag-description) $
vscode ➜ /workspaces/flowpipe (fix-pipeline-run-flag-description) $ go run . help pipeline list
List pipelines from the current mod and its direct dependents.

Usage:
  flowpipe pipeline list [flags]

Flags:
  -h, --help   help for list

Global Flags:
      --config-path string    Colon separated list of paths to search for workspace files, in order of decreasing precedence
      --host string           API server host, including the port number
      --insecure              Skip TLS verification
      --mod-location string   Path to the workspace working directory (default "/workspaces/flowpipe")
      --output output         Output format; one of: pretty, plain, yaml, json (default pretty)
      --var stringArray       Specify the value of a variable
      --var-file strings      Specify an .fpvar file containing variable values
      --workspace string      The workspace to use (default "default")
vscode ➜ /workspaces/flowpipe (fix-pipeline-run-flag-description) $
vscode ➜ /workspaces/flowpipe (fix-pipeline-run-flag-description) $
vscode ➜ /workspaces/flowpipe (fix-pipeline-run-flag-description) $ go run . help pipeline show
Show details of a pipeline from the current mod or its direct dependents.

Usage:
  flowpipe pipeline show <pipeline-name> [flags]

Flags:
  -h, --help   help for show

Global Flags:
      --config-path string    Colon separated list of paths to search for workspace files, in order of decreasing precedence
      --host string           API server host, including the port number
      --insecure              Skip TLS verification
      --mod-location string   Path to the workspace working directory (default "/workspaces/flowpipe")
      --output output         Output format; one of: pretty, plain, yaml, json (default pretty)
      --var stringArray       Specify the value of a variable
      --var-file strings      Specify an .fpvar file containing variable values
      --workspace string      The workspace to use (default "default")
vscode ➜ /workspaces/flowpipe (fix-pipeline-run-flag-description) $ 
```