### PR TITLE
Use active link under the pipelines badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 <a href="https://flowpipe.io"><img width="67%" src="https://flowpipe.io/images/flowpipe_wordmark_outline.png"></a>
 
 [![libraries](https://img.shields.io/endpoint?url=https://turbot.com/api/badge-stats?stat=fp_libraries)](https://hub.flowpipe.io) &nbsp;
-[![pipelines](https://img.shields.io/endpoint?url=https://turbot.com/api/badge-stats?stat=fp_pipelines)](https://hub.flowpipe.io/mods) &nbsp;
+[![pipelines](https://img.shields.io/endpoint?url=https://turbot.com/api/badge-stats?stat=fp_pipelines)](https://hub.flowpipe.io) &nbsp;
 [![slack](https://img.shields.io/endpoint?url=https://turbot.com/api/badge-stats?stat=slack)](https://turbot.com/community/join) &nbsp;
 [![maintained by](https://img.shields.io/badge/maintained%20by-Turbot-blue)](https://turbot.com)
 


### PR DESCRIPTION
The link:
https://hub.flowpipe.io/mods

does not work.

Similar to:
- turbot/tailpipe#583.