### PR TITLE
CHANGELOG for flowpipe v1.2.2 (pgx v5.9.2, CVE-2026-41889)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Flowpipe
 
+## v1.2.2 [2026-05-19]
+
+_Security_
+
+* Bump `github.com/jackc/pgx/v5` to v5.9.2 to remediate CVE-2026-41889 ([GHSA-j88v-2chj-qfwx](https://github.com/advisories/GHSA-j88v-2chj-qfwx)).
+
+_Dependencies_
+
+* Update Go to 1.26.1.
+
 ## v1.2.1 [2026-04-15]
 
 _Security_


### PR DESCRIPTION
## Summary

Release prep for flowpipe **v1.2.2**. Adds the CHANGELOG entry for the pgx v5.9.2 + Go 1.26.1 fix already merged on `v1.2.x` (#1064).

## Changes

- Added `## v1.2.2 [2026-05-19]` entry to `CHANGELOG.md`:
  - _Security_: Bump `github.com/jackc/pgx/v5` to v5.9.2 to remediate CVE-2026-41889 (GHSA-j88v-2chj-qfwx).
  - _Dependencies_: Update Go to 1.26.1.

## Notes

- The CHANGELOG had **no `## vTBD [TBD]` placeholder block**; per the release runbook fallback, a new `## v1.2.2 [2026-05-19]` entry was added at the top matching the existing entry style (`_Security_` / `_Dependencies_` sections, as used in v1.2.1).
- PR only — no merge, no tag, no release.
- flowpipe PRs cannot be self-approved; review/approval required from cbruno10 / MichaelBurgess / vhadianto.