### PR TITLE
Bump lodash and lodash-es from 4.17.23 to 4.18.1 in /ui/form

### DIFF
--- a/ui/form/package.json
+++ b/ui/form/package.json
@@ -45,8 +45,8 @@
     "glob": "10.5.0",
     "tar": "7.5.13",
     "@remix-run/router": "1.23.2",
-    "lodash": "4.17.23",
-    "lodash-es": "4.17.23",
+    "lodash": "4.18.1",
+    "lodash-es": "4.18.1",
     "rollup": "4.60.1",
     "flatted": "3.4.2"
   }

--- a/ui/form/yarn.lock
+++ b/ui/form/yarn.lock
@@ -2867,10 +2867,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"lodash-es@npm:4.17.23":
-  version: 4.17.23
-  resolution: "lodash-es@npm:4.17.23"
-  checksum: 10c0/3150fb6660c14c7a6b5f23bd11597d884b140c0e862a17fdb415aaa5ef7741523182904a6b7929f04e5f60a11edb5a79499eb448734381c99ffb3c4734beeddd
+"lodash-es@npm:4.18.1":
+  version: 4.18.1
+  resolution: "lodash-es@npm:4.18.1"
+  checksum: 10c0/35d4dcf87ef07f8d090f409447575800108057e360b445f590d0d25d09e3d1e33a163d2fc100d4d072b0f901d5e2fc533cd7c4bfd8eeb38a06abec693823c8b8
   languageName: node
   linkType: hard
 
@@ -2881,10 +2881,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"lodash@npm:4.17.23":
-  version: 4.17.23
-  resolution: "lodash@npm:4.17.23"
-  checksum: 10c0/1264a90469f5bb95d4739c43eb6277d15b6d9e186df4ac68c3620443160fc669e2f14c11e7d8b2ccf078b81d06147c01a8ccced9aab9f9f63d50dcf8cace6bf6
+"lodash@npm:4.18.1":
+  version: 4.18.1
+  resolution: "lodash@npm:4.18.1"
+  checksum: 10c0/757228fc68805c59789e82185135cf85f05d0b2d3d54631d680ca79ec21944ec8314d4533639a14b8bcfbd97a517e78960933041a5af17ecb693ec6eecb99a27
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Resolves CVE-2026-4800 (HIGH). Both `lodash` and `lodash-es` are pinned via the `resolutions` block in `ui/form/package.json`; 4.17.23 is within the vulnerable range (`<= 4.17.23`), fixed in 4.18.1.

Dependabot did not raise a PR for these (they sit in `resolutions`, not as direct deps), so this is the manual override. Minor bump, no API changes; `tsc` + `vite build` pass locally. Matches the equivalent powerpipe bump (lodash 4.17.23→4.18.1).