### PR TITLE
Bump pipe-fittings to v1.7.4 (fix mod upgrade with read-only git packs)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -59,7 +59,7 @@ require (
 require (
 	github.com/iancoleman/strcase v0.3.0
 	github.com/robfig/cron/v3 v3.0.1
-	github.com/turbot/pipe-fittings v1.7.2
+	github.com/turbot/pipe-fittings v1.7.4
 	github.com/turbot/terraform-components v0.0.0-20231213122222-1f3526cab7a7
 )
 

--- a/go.sum
+++ b/go.sum
@@ -676,8 +676,8 @@ github.com/turbot/flowpipe-sdk-go v1.0.0 h1:q8zrZ/KKECDDCl5139CzPJUXfZTiS0vITOx7
 github.com/turbot/flowpipe-sdk-go v1.0.0/go.mod h1:tP5opISn4bPv8ubRN7Kt1xvXJXgDkd8LEV0iAGHDar4=
 github.com/turbot/go-kit v0.10.0-rc.0 h1:kd+jp2ibbIV33Hc8SsMAN410Dl9Pz6SJ40axbKUlSoA=
 github.com/turbot/go-kit v0.10.0-rc.0/go.mod h1:fFQqR59I5z5JeeBLfK1PjSifn4Oprs3NiQx0CxeSJxs=
-github.com/turbot/pipe-fittings v1.7.2 h1:/0GgcEihAiZe5Bxq56xMyGD7mgFStkx3fjq9AE2slH0=
-github.com/turbot/pipe-fittings v1.7.2/go.mod h1:U4zHQQWR1yoYBQv0X9d3PvK2WU13hS7L2TfuF9wr8Ck=
+github.com/turbot/pipe-fittings v1.7.4 h1:VfdHYxPcBmGp1Wzcy3ydMakm/lIU8xlh6f72e9sz49A=
+github.com/turbot/pipe-fittings v1.7.4/go.mod h1:U4zHQQWR1yoYBQv0X9d3PvK2WU13hS7L2TfuF9wr8Ck=
 github.com/turbot/pipes-sdk-go v0.9.1 h1:2yRojY2wymvJn6NQyE6A0EDFV267MNe+yDLxPVvsBwM=
 github.com/turbot/pipes-sdk-go v0.9.1/go.mod h1:Mb+KhvqqEdRbz/6TSZc2QWDrMa5BN3E4Xw+gPt2TRkc=
 github.com/turbot/steampipe-plugin-code v0.7.0 h1:SROYIo/TI/Q/YNfXK+sAIS71umypUFm1Uz851TmoJkM=


### PR DESCRIPTION
## What

- `pipe-fittings` v1.7.2 -> **v1.7.4**

go-git is already at v5.19.1 on develop (#1068); this pairs it with the pipe-fittings fix.

## Why

go-git >= v5.17 writes git pack files read-only (`fixPermissions`). The shared `pipe-fittings` mod installer's shadow-directory commit could not overwrite them, so a mod **re-install or upgrade** failed with `permission denied`. flowpipe floats go-git to v5.19.1, so it hit this once a mod was upgraded (first install was unaffected, which is why it stayed latent).

pipe-fittings v1.7.4 (turbot/pipe-fittings#802, the v1.7.x backport of #801) makes `commitShadow` restore write permission before the copy, so it tolerates read-only packs.
